### PR TITLE
Replace .github README with this revised version

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,17 +2,17 @@
 
 [(**Français**)](#lorganisation-github-aafc-bioinfo-aac)
 
-Welcome to `AAFC-Bioinfo-AAC`, a central repository for reproducible bioinformatics code and pipelines, published following AAFC-endorsed guidelines and processes:
-- 🌐 Public Repositories  
-[Browse the full catalogue](https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories)
-- 🛡️ Active Private Repositories (internal access only)  
-[View the private repo catalogue](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx)
+Welcome to `AAFC-Bioinfo-AAC`, a central repository for reproducible bioinformatics code and pipelines published by AAFC staff following AAFC-endorsed guidelines and processes:
 
-All AAFC staff are encouraged to use/contribute to this central GitHub organization. Refer [Quickstart guide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) for details. 
+- 🌐 [AAFC Bioinformatics Code Catalogue (ABCC)](https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories): Browse the full catalogue of published code repositories.
+
+- 🛡️ [List of private code repositories under active development](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx) (*internal access only*) 
+
+The [Quickstart guide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) provides details on how AAFC staff can contribute to the `AAFC-Bioinfo-AAC` GitHub organization.
 
 ## About
 
-The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions and Innovation (SSI)` and led by members of the `Bioinformatics Research Support Network (BRSN)` of [Agriculture and Agri-Food Canada (AAFC)](https://agriculture.canada.ca/en), was launched as a core deliverable of the [AAFC Bioinformatics Code Catalogue (ABCC) project](https://001gc.sharepoint.com/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d'AAC.aspx) (*internal access only*) with the following objectives:
+The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions and Innovation (SSI)`, was launched as a core deliverable of the [AAFC Bioinformatics Code Catalogue (ABCC) project](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*internal access only*), led by members of the `Bioinformatics Research Support Network (BRSN)` of [Agriculture and Agri-Food Canada (AAFC)](https://agriculture.canada.ca/en), with the following objectives:
 - to provide a centralized platform for version-controlled code, computational pipelines, and analytical resources;
 - to promote standardized code development practices;
 - to facilitate code reuse and transparency in accordance with Government of Canada guidances on [Open-source code publication](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/open-source-software/guide-for-publishing-open-source-code.html) and [FAIR-aligned practices](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/information-management/guidance-assessing-readiness-manage-data-according-findable-accessible-interoperable-reusable-principles.html);
@@ -24,16 +24,18 @@ The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions a
 
 [(English)](#the-aafc-bioinfo-aac-github-organisation)
 
-Bienvenue! Nous encourageons les scientifiques, bio-informaticiens, analystes et développeurs d’AAC à contribuer au code bio-informatique et aux pipelines reproductibles dans l’organisation GitHub AAFC-Bioinfo-AAC. **Le personnel d'AAC** peut demander la création de nouveaux dépôts ou de services connexes en soumettant un billet via l'application **MyITCentreTI**, sous la catégorie: ***Support informatique scientifique > Science Code Catalogue***. Ce [guide de démarrage rapide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) vous aidera à débuter avec la création, la contribution et la publication de dépôts.
+Bienvenue dans `AAFC-Bioinfo-AAC`, un dépôt central de code et de pipelines bioinformatiques reproductibles publiés par le personnel de l’AAC conformément aux lignes directrices et aux processus approuvés par l’AAC:
 
-🌐🔓 Une liste des dépôts publiés est disponible à l'adresse: [Répertoire de Codes Bioinformatique d'AAC](https://github.com/AAFC-Bioinfo-AAC/ABCC-published-repos). Pour amorcer une collaboration, ouvrez un billet (issue) GitHub dans le dépôt concerné.
+- 🌐 [Répertoire de Codes Bioinformatique d'AAC (RCBA)](https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories): Parcourez le catalogue complet des dépôts de code publiés.
 
-🛡️🔒 Une liste de tous les dépôts privés actifs est [**accessible au sein du réseau interne d'AAC**](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx?csf=1&web=1&e=jXxrXb).
+- 🛡️ [Liste des dépôts de code privés en cours de développement](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx) (*accès interne uniquement*)
 
----
+Le [Guide de démarrage rapide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) fournit des détails sur la façon dont le personnel de l’AAC peut contribuer à l’organisation GitHub `AAFC-Bioinfo-AAC`.
 
-> ℹ️ Le compte d'organisation GitHub ***AAC-Bioinfo-AAC***, géré par ***Solutions scientifiques et innovation (SSI) d'AAC***, a été lancé comme un élément clé du projet de ***Répertoire de Codes Bioinformatique d'AAC (RCBA)***, dirigé par le ***Réseau de Soutien à la Recherche en Bioinformatique (RSRB)*** d'[Agriculture et Agroalimentaire Canada (AAC)](https://agriculture.canada.ca/fr). Le projet RCBA vise à:
+## À propos
+
+Le compte d’organisation GitHub `AAFC-Bioinfo-AAC`, géré par `Solutions scientifiques et innovation (SSI) d'AAC`, a été lancé en tant que livrable principal du projet de [Répertoire de Codes Bioinformatique d'AAC (RCBA)](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*accès interne uniquement*), dirigé par des membres du `Réseau de Soutien à la Recherche en Bioinformatique (RSRB)` d'[Agriculture et Agroalimentaire Canada (AAC)](https://agriculture.canada.ca/fr) avec les objectifs suivants:
 - fournir une plateforme centralisée pour le code à version contrôlée, de pipelines informatiques et de ressources analytiques;
 - promouvoir des pratiques normalisées de développement de code;
-- faciliter la réutilisation du code et la transparence selon les lignes directrices du Gouvernement du Canada sur la [publication de code source libre](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques/logiciels-libres/guide-pour-la-publication-du-code-source-libre.html) et aux [pratiques conformes à la norme FAIR](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques/gestion-information/orientation-evaluation-etat-preparation-gestion-donnees-selon-principes-donnees-faciles-trouver-accessibles-interoperables-reutilisables.html).
-
+- faciliter la réutilisation du code et la transparence selon les lignes directrices du Gouvernement du Canada sur la [publication de code source libre](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques/logiciels-libres/guide-pour-la-publication-du-code-source-libre.html) et aux [pratiques conformes à la norme FAIR](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques/gestion-information/orientation-evaluation-etat-preparation-gestion-donnees-selon-principes-donnees-faciles-trouver-accessibles-interoperables-reutilisables.html);
+- simplifier le processus de publication du code.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-# The AAFC-Bioinfo-AAC Github organisation
+# The `AAFC-Bioinfo-AAC` Github organisation
 
 [(**Français**)](#lorganisation-github-aafc-bioinfo-aac)
 
@@ -20,7 +20,7 @@ The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions a
 
 ---
 
-# L’organisation GitHub AAFC-Bioinfo-AAC
+# L’organisation GitHub `AAFC-Bioinfo-AAC`
 
 [(English)](#the-aafc-bioinfo-aac-github-organisation)
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -23,7 +23,7 @@ The `AAFC-Bioinfo-AAC` GitHub organization, managed by AAFC's `Science Solutions
 
 # L’organisation GitHub `AAFC-Bioinfo-AAC`
 
-[(English)](#the-aafc-bioinfo-aac-github-organisation)
+[(**English**)](#the-aafc-bioinfo-aac-github-organisation)
 
 Bienvenue dans `AAFC-Bioinfo-AAC`, un dépôt central de code et de pipelines bioinformatiques reproductibles publiés par le personnel d'[Agriculture et Agroalimentaire Canada (AAC)](https://agriculture.canada.ca/fr) conformément aux lignes directrices et aux processus approuvés par d’AAC:
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 [(**Français**)](#lorganisation-github-aafc-bioinfo-aac)
 
-Welcome to `AAFC-Bioinfo-AAC`, a central repository for reproducible bioinformatics code and pipelines published by AAFC staff following AAFC-endorsed guidelines and processes:
+Welcome to `AAFC-Bioinfo-AAC`, a central repository for reproducible bioinformatics code and pipelines published by [Agriculture and Agri-Food Canada (AAFC)](https://agriculture.canada.ca/en) staff following AAFC-endorsed guidelines and processes:
 
 - 🌐 [AAFC Bioinformatics Code Catalogue (ABCC)](https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories): Browse the full catalogue of published code repositories.
 
@@ -12,7 +12,7 @@ The [Quickstart guide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) pr
 
 ## About
 
-The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions and Innovation (SSI)`, was launched as a core deliverable of the [AAFC Bioinformatics Code Catalogue (ABCC) project](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*internal access only*), led by members of the `Bioinformatics Research Support Network (BRSN)` of [Agriculture and Agri-Food Canada (AAFC)](https://agriculture.canada.ca/en), with the following objectives:
+The `AAFC-Bioinfo-AAC` GitHub organization, managed by AAFC's `Science Solutions and Innovation (SSI)`, was launched as a core deliverable of the [AAFC Bioinformatics Code Catalogue (ABCC) project](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*internal access only*), led by members of AAFC's `Bioinformatics Research Support Network (BRSN)`, with the following objectives:
 
 - to provide a centralized platform for version-controlled code, computational pipelines, and analytical resources;
 - to promote standardized code development practices;
@@ -25,7 +25,7 @@ The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions a
 
 [(English)](#the-aafc-bioinfo-aac-github-organisation)
 
-Bienvenue dans `AAFC-Bioinfo-AAC`, un dépôt central de code et de pipelines bioinformatiques reproductibles publiés par le personnel de l’AAC conformément aux lignes directrices et aux processus approuvés par l’AAC:
+Bienvenue dans `AAFC-Bioinfo-AAC`, un dépôt central de code et de pipelines bioinformatiques reproductibles publiés par le personnel d'[Agriculture et Agroalimentaire Canada (AAC)](https://agriculture.canada.ca/fr) conformément aux lignes directrices et aux processus approuvés par d’AAC:
 
 - 🌐 [Répertoire de Codes Bioinformatique d'AAC (RCBA)](https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories): Parcourez le catalogue complet des dépôts de code publiés.
 
@@ -35,7 +35,7 @@ Le [Guide de démarrage rapide](https://github.com/AAFC-Bioinfo-AAC/quick-start-
 
 ## À propos
 
-Le compte d’organisation GitHub `AAFC-Bioinfo-AAC`, géré par `Solutions scientifiques et innovation (SSI) d'AAC`, a été lancé en tant que livrable principal du projet de [Répertoire de Codes Bioinformatique d'AAC (RCBA)](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*accès interne uniquement*), dirigé par des membres du `Réseau de Soutien à la Recherche en Bioinformatique (RSRB)` d'[Agriculture et Agroalimentaire Canada (AAC)](https://agriculture.canada.ca/fr) avec les objectifs suivants:
+Le compte d’organisation GitHub `AAFC-Bioinfo-AAC`, géré par `Solutions scientifiques et innovation (SSI)` d'AAC, a été lancé en tant que livrable principal du projet de [Répertoire de Codes Bioinformatique d'AAC (RCBA)](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*accès interne uniquement*), dirigé par des membres du `Réseau de Soutien à la Recherche en Bioinformatique (RSRB)` d'AAC avec les objectifs suivants:
 
 - fournir une plateforme centralisée pour le code à version contrôlée, de pipelines informatiques et de ressources analytiques;
 - promouvoir des pratiques normalisées de développement de code;

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,18 +2,21 @@
 
 [(**Français**)](#lorganisation-github-aafc-bioinfo-aac)
 
-Welcome! We encourage AAFC scientists, bioinformaticians, analysts, and developers to contribute bioinformatics code and reproducible pipelines to the ***AAFC-Bioinfo-AAC*** GitHub organization. **AAFC personnel** may request the creation of new repositories or related services by submitting a ticket via the ***MyITCentreTI*** application under category: ***Science IT Support > Science Code Catalogue***. This [Quickstart guide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) will help you get started with repository creation, contribution, and publication.
+Welcome to `AAFC-Bioinfo-AAC`, a central repository for reproducible bioinformatics code and pipelines, published following AAFC-endorsed guidelines and processes:
+- 🌐 Public Repositories  
+[Browse the full catalogue](https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories)
+- 🛡️ Active Private Repositories (internal access only)  
+[View the private repo catalogue](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx)
 
-🌐🔓 A curated list of published repositories is available at: [AAFC Bioinformatics Code Catalogue](https://github.com/AAFC-Bioinfo-AAC/ABCC-RCBA-Catalogue). To initiate collaboration, open a GitHub issue in the relevant repository.
+All AAFC staff are encouraged to use/contribute to this central GitHub organization. Refer [Quickstart guide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) for details. 
 
-🛡️🔒  A list of all active private repositories is [**accessible internally within the AAFC network**](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx?csf=1&web=1&e=jXxrXb).
+## About
 
----
-
-> ℹ️ The ***AAFC-Bioinfo-AAC*** GitHub organization, managed by ***AAFC Science Solutions and Innovation (SSI)*** centre, was launched as a core deliverable of the ***AAFC Bioinformatics Code Catalogue (ABCC)*** project led by the ***Bioinformatics Research Support Network (BRSN)*** of [Agriculture and Agri-Food Canada (AAFC)](https://agriculture.canada.ca/en). The ABCC project aims to:
->- provide a centralized platform for version-controlled code, computational pipelines, and analytical resources;
->- promote standardized code development practices;
->- facilitate code reuse and transparency in accordance with Government of Canada guidances on [Open-source code publication](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/open-source-software/guide-for-publishing-open-source-code.html) and [FAIR-aligned practices](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/information-management/guidance-assessing-readiness-manage-data-according-findable-accessible-interoperable-reusable-principles.html).
+The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions and Innovation (SSI)` and led by members of the `Bioinformatics Research Support Network (BRSN)` of [Agriculture and Agri-Food Canada (AAFC)](https://agriculture.canada.ca/en), was launched as a core deliverable of the [AAFC Bioinformatics Code Catalogue (ABCC) project](https://001gc.sharepoint.com/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d'AAC.aspx) (*internal access only*) with the following objectives:
+- to provide a centralized platform for version-controlled code, computational pipelines, and analytical resources;
+- to promote standardized code development practices;
+- to facilitate code reuse and transparency in accordance with Government of Canada guidances on [Open-source code publication](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/open-source-software/guide-for-publishing-open-source-code.html) and [FAIR-aligned practices](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/information-management/guidance-assessing-readiness-manage-data-according-findable-accessible-interoperable-reusable-principles.html);
+- to simplify the code publication process.
 
 ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,13 +6,14 @@ Welcome to `AAFC-Bioinfo-AAC`, a central repository for reproducible bioinformat
 
 - 🌐 [AAFC Bioinformatics Code Catalogue (ABCC)](https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories): Browse the full catalogue of published code repositories.
 
-- 🛡️ [List of private code repositories under active development](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx) (*internal access only*) 
+- 🛡️ [List of private code repositories under active development](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/abcc-private-repos.aspx) (*internal access only*)
 
 The [Quickstart guide](https://github.com/AAFC-Bioinfo-AAC/quick-start-guide) provides details on how AAFC staff can contribute to the `AAFC-Bioinfo-AAC` GitHub organization.
 
 ## About
 
 The `AAFC-Bioinfo-AAC` GitHub organization, managed by `AAFC Science Solutions and Innovation (SSI)`, was launched as a core deliverable of the [AAFC Bioinformatics Code Catalogue (ABCC) project](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*internal access only*), led by members of the `Bioinformatics Research Support Network (BRSN)` of [Agriculture and Agri-Food Canada (AAFC)](https://agriculture.canada.ca/en), with the following objectives:
+
 - to provide a centralized platform for version-controlled code, computational pipelines, and analytical resources;
 - to promote standardized code development practices;
 - to facilitate code reuse and transparency in accordance with Government of Canada guidances on [Open-source code publication](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/open-source-software/guide-for-publishing-open-source-code.html) and [FAIR-aligned practices](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/information-management/guidance-assessing-readiness-manage-data-according-findable-accessible-interoperable-reusable-principles.html);
@@ -35,6 +36,7 @@ Le [Guide de démarrage rapide](https://github.com/AAFC-Bioinfo-AAC/quick-start-
 ## À propos
 
 Le compte d’organisation GitHub `AAFC-Bioinfo-AAC`, géré par `Solutions scientifiques et innovation (SSI) d'AAC`, a été lancé en tant que livrable principal du projet de [Répertoire de Codes Bioinformatique d'AAC (RCBA)](https://001gc.sharepoint.com/:u:/r/sites/42732/SitePages/AAFC-Bioinformatics-Code-Catalogue_R%C3%A9pertoire-de-codes-Bioinformatique-d%27AAC.aspx) (*accès interne uniquement*), dirigé par des membres du `Réseau de Soutien à la Recherche en Bioinformatique (RSRB)` d'[Agriculture et Agroalimentaire Canada (AAC)](https://agriculture.canada.ca/fr) avec les objectifs suivants:
+
 - fournir une plateforme centralisée pour le code à version contrôlée, de pipelines informatiques et de ressources analytiques;
 - promouvoir des pratiques normalisées de développement de code;
 - faciliter la réutilisation du code et la transparence selon les lignes directrices du Gouvernement du Canada sur la [publication de code source libre](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques/logiciels-libres/guide-pour-la-publication-du-code-source-libre.html) et aux [pratiques conformes à la norme FAIR](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/innovations-gouvernementales-numeriques/gestion-information/orientation-evaluation-etat-preparation-gestion-donnees-selon-principes-donnees-faciles-trouver-accessibles-interoperables-reutilisables.html);


### PR DESCRIPTION
Changes made:
- Trimmed down EN text and translated changes to FR. 
- Replaced link to [AAFC Bioinformatics Code Catalogue](https://github.com/AAFC-Bioinfo-AAC/ABCC-RCBA-Catalogue) published-repos with this URL search: https://github.com/search?q=org:AAFC-Bioinfo-AAC+is:public+-topic:do-not-catalogue&type=repositories, using _topic:do-not-catalogue_ on repos that shouldn't show up here, like the Quickstart guide. 

Help requested with:
- Reviewing the FR translation for accuracy
- Adding _topic:do-not-catalogue_ to the **.github** repo too, in its About settings, and adding some description there, for example, "A central repository for reproducible bioinformatics code and pipelines published by AAFC staff following AAFC-endorsed guidelines and processes."
- Deleting redundant repo: [published-repos](https://github.com/AAFC-Bioinfo-AAC/published-repos)


